### PR TITLE
Support multiple player IDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squishjs",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "squish & unsquish stuff",
   "scripts": {
     "test": "node testRunner.js"

--- a/src/GameNode.js
+++ b/src/GameNode.js
@@ -2,14 +2,14 @@ const listenable = require("./util/listenable");
 const InternalGameNode = require('./InternalGameNode');
 const Shapes = require('./Shapes');
 
-const gameNode = (color, onClick, coordinates2d, border, fill, text, asset, playerId, effects, input) => {
-    const node = new InternalGameNode(color, onClick, coordinates2d, border, fill, text, asset, playerId, effects, input);
+const gameNode = (color, onClick, coordinates2d, border, fill, text, asset, playerIds, effects, input) => {
+    const node = new InternalGameNode(color, onClick, coordinates2d, border, fill, text, asset, playerIds, effects, input);
     return listenable(node, node.onStateChange.bind(node));
 };
 
 class Shape {
-    constructor(color, shapeType, shapeInfo, playerId, onClick, effects, input) {
-        this.node = gameNode(color, onClick, shapeInfo.coordinates2d, shapeInfo.border, shapeInfo.fill, null, null, playerId, effects, input);
+    constructor(color, shapeType, shapeInfo, playerIds, onClick, effects, input) {
+        this.node = gameNode(color, onClick, shapeInfo.coordinates2d, shapeInfo.border, shapeInfo.fill, null, null, playerIds, effects, input);
         this.id = this.node.id;
     }
 
@@ -37,8 +37,8 @@ class Shape {
 }
 
 class Text {
-    constructor(textInfo, playerId, input) {
-        this.node = gameNode(null, null, null, null, null, textInfo, null, playerId, null, input);
+    constructor(textInfo, playerIds, input) {
+        this.node = gameNode(null, null, null, null, null, textInfo, null, playerIds, null, input);
         this.id = this.node.id;
     }
 
@@ -66,8 +66,8 @@ class Text {
 }
 
 class Asset {
-    constructor(onClick, coordinates2d, assetInfo, playerId) {
-        this.node = gameNode(null, onClick, coordinates2d, null, null, null, assetInfo, playerId);
+    constructor(onClick, coordinates2d, assetInfo, playerIds) {
+        this.node = gameNode(null, onClick, coordinates2d, null, null, null, assetInfo, playerIds);
         this.id = this.node.id;
     }
 

--- a/src/InternalGameNode.js
+++ b/src/InternalGameNode.js
@@ -1,7 +1,7 @@
 let id = 0;
 
 class InternalGameNode {
-    constructor(color, onClick, coordinates2d, border, fill, text, asset, playerId = 0, effects = null, input = null) {
+    constructor(color, onClick, coordinates2d, border, fill, text, asset, playerIds = [], effects = null, input = null) {
         this.id = id++;
         this.children = new Array();
         this.color = color;
@@ -14,7 +14,7 @@ class InternalGameNode {
         this.effects = effects;
         this.input = input;
         this.listeners = new Set();
-        this.playerId = Number(playerId);
+        this.playerIds = playerIds || [];
     }
 
     addChild(node) {

--- a/src/InternalGameNode.js
+++ b/src/InternalGameNode.js
@@ -14,6 +14,9 @@ class InternalGameNode {
         this.effects = effects;
         this.input = input;
         this.listeners = new Set();
+        if (playerIds && !(playerIds instanceof Array)) {
+            playerIds = [playerIds];
+        }
         this.playerIds = playerIds || [];
     }
 

--- a/src/squish.js
+++ b/src/squish.js
@@ -38,14 +38,10 @@ const squishSpec = {
             return [squished[0], squished[1], squished[2], squished[3]];
         }
     },
-    playerId: {
+    playerIds: {
         type: PLAYER_ID_SUBTYPE,
-        squish: (i) => {
-            return [i];
-        }, 
-        unsquish: (squished) => {
-            return squished[0];
-        }
+        squish: (i) => i,
+        unsquish: (squished) => squished
     }, 
     pos: {
         type: POS_SUBTYPE,
@@ -287,7 +283,7 @@ const squishSpec = {
 const squishSpecKeys = [
     'id', 
     'color', 
-    'playerId', 
+    'playerIds', 
     'coordinates2d',
     'fill',
     'pos', 

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -73,6 +73,44 @@ test("Simple shape", () => {
     compareSquished(gameNode.node, unsquishedGameNode);
 });
 
+test("Simple shape visible to 2 players", () => {
+    const gameNode = new GameNode.Shape(
+        COLORS.RED,
+        Shapes.POLYGON,
+        {
+            coordinates2d: ShapeUtils.rectangle(10, 10, 50, 50),
+            fill: COLORS.RED
+        },
+        [1, 2]
+    );
+    const squishedGameNode = squish(gameNode.node);
+    const unsquishedGameNode = unsquish(squishedGameNode);
+    compareSquished(gameNode.node, unsquishedGameNode);
+    assert(unsquishedGameNode.playerIds.length == 2);
+    assert(unsquishedGameNode.playerIds[0] == 1);
+    assert(unsquishedGameNode.playerIds[1] == 2);
+});
+
+test("Simple text visible to 255 players", () => {
+    const playerIds = Array.from({length: 255}, (_, i) => i + 1);
+    const gameNode = new GameNode.Text({
+        text: 'Hello, world!',
+        x: 4,
+        y: 20,
+        size: 5,
+        align: 'center',
+        color: COLORS.RED
+    }, playerIds);
+
+    const squishedGameNode = squish(gameNode.node);
+    const unsquishedGameNode = unsquish(squishedGameNode);
+    compareSquished(gameNode.node, unsquishedGameNode);
+    assert(unsquishedGameNode.playerIds.length == 255);
+    for (let i = 0; i < playerIds.length; i++) {
+        assert(unsquishedGameNode.playerIds[i] == playerIds[i]);
+    }
+});
+
 test("Text node", () => {
     const gameNode = new GameNode.Text({
         text: 'ayy lmao',
@@ -118,7 +156,7 @@ test("Shape with shadow", () => {
             coordinates2d: ShapeUtils.rectangle(20, 20, 30, 30),
             fill: COLORS.WHITE
         },
-        42,
+        [42],
         null,
         {
             shadow: {


### PR DESCRIPTION
Update squish spec to support multiple player IDs on game nodes. `playerId` is no longer a thing and it has been replaced with `playerIds`